### PR TITLE
Add Row Description Fields to SimpleQuery response

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -557,6 +557,7 @@ impl CopyBothResponseBody {
     }
 }
 
+#[derive(PartialEq, Eq)]
 pub struct DataRowBody {
     storage: Bytes,
     len: u16,
@@ -898,6 +899,70 @@ impl<'a> Field<'a> {
     #[inline]
     pub fn format(&self) -> i16 {
         self.format
+    }
+}
+
+/// A struct representing the fields of a RowDescription message. Clones the fields to avoid keeping
+/// the `RowDescriptionMessage`.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct OwnedField {
+    name: String,
+    table_oid: Oid,
+    column_id: i16,
+    type_oid: Oid,
+    type_size: i16,
+    type_modifier: i32,
+    format: i16,
+}
+
+impl OwnedField {
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[inline]
+    pub fn table_oid(&self) -> Oid {
+        self.table_oid
+    }
+
+    #[inline]
+    pub fn column_id(&self) -> i16 {
+        self.column_id
+    }
+
+    #[inline]
+    pub fn type_oid(&self) -> Oid {
+        self.type_oid
+    }
+
+    #[inline]
+    pub fn type_size(&self) -> i16 {
+        self.type_size
+    }
+
+    #[inline]
+    pub fn type_modifier(&self) -> i32 {
+        self.type_modifier
+    }
+
+    #[inline]
+    pub fn format(&self) -> i16 {
+        self.format
+    }
+}
+
+impl From<Field<'_>> for OwnedField {
+    fn from(f: Field<'_>) -> Self {
+        OwnedField {
+            name: f.name().to_string(),
+            table_oid: f.table_oid(),
+            column_id: f.column_id(),
+            type_oid: f.type_oid(),
+            type_size: f.type_size(),
+            type_modifier: f.type_modifier(),
+            format: f.format(),
+        }
     }
 }
 

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -141,6 +141,7 @@ pub use crate::to_statement::ToStatement;
 pub use crate::transaction::Transaction;
 pub use crate::transaction_builder::{IsolationLevel, TransactionBuilder};
 use crate::types::ToSql;
+pub use postgres_protocol::message::backend::OwnedField;
 pub use postgres_protocol::message::backend::Message;
 
 pub mod binary_copy;
@@ -240,6 +241,7 @@ pub enum AsyncMessage {
 
 /// Message returned by the `SimpleQuery` stream.
 #[non_exhaustive]
+#[derive(Debug)]
 pub enum SimpleQueryMessage {
     /// A row of data.
     Row(SimpleQueryRow),

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -6,7 +6,7 @@ use crate::statement::Column;
 use crate::types::{FromSql, Type, WrongType};
 use crate::{Error, Statement};
 use fallible_iterator::FallibleIterator;
-use postgres_protocol::message::backend::DataRowBody;
+use postgres_protocol::message::backend::{OwnedField, DataRowBody};
 use std::fmt;
 use std::ops::Range;
 use std::str;
@@ -29,6 +29,12 @@ impl AsName for Column {
 impl AsName for String {
     fn as_name(&self) -> &str {
         self
+    }
+}
+
+impl AsName for OwnedField {
+    fn as_name(&self) -> &str {
+        self.name()
     }
 }
 
@@ -196,8 +202,9 @@ impl AsName for SimpleColumn {
 }
 
 /// A row of data returned from the database by a simple query.
+#[derive(Eq, PartialEq)]
 pub struct SimpleQueryRow {
-    columns: Arc<[SimpleColumn]>,
+    fields: Arc<[OwnedField]>,
     body: DataRowBody,
     ranges: Vec<Option<Range<usize>>>,
 }
@@ -205,20 +212,29 @@ pub struct SimpleQueryRow {
 impl SimpleQueryRow {
     #[allow(clippy::new_ret_no_self)]
     pub(crate) fn new(
-        columns: Arc<[SimpleColumn]>,
+        fields: Arc<[OwnedField]>,
         body: DataRowBody,
     ) -> Result<SimpleQueryRow, Error> {
         let ranges = body.ranges().collect().map_err(Error::parse)?;
         Ok(SimpleQueryRow {
-            columns,
+            fields,
             body,
             ranges,
         })
     }
 
-    /// Returns information about the columns of data in the row.
-    pub fn columns(&self) -> &[SimpleColumn] {
-        &self.columns
+    /// Returns information about the columns of data in the row. Performs an allocation to return
+    /// each name as a `SimpleColumn`. To avoid the allocation, use `SimpleQueryRow::fields()`.
+    pub fn columns(&self) -> Vec<SimpleColumn> {
+        self.fields
+            .iter()
+            .map(|f| SimpleColumn::new(f.name().to_string()))
+            .collect()
+    }
+
+    /// Returns the fields found in the RowDescription message with information on each column.
+    pub fn fields(&self) -> &[OwnedField] {
+        &self.fields
     }
 
     /// Determines if the row contains no values.
@@ -228,7 +244,7 @@ impl SimpleQueryRow {
 
     /// Returns the number of values in the row.
     pub fn len(&self) -> usize {
-        self.columns.len()
+        self.fields.len()
     }
 
     /// Returns a value from the row.
@@ -260,12 +276,22 @@ impl SimpleQueryRow {
     where
         I: RowIndex + fmt::Display,
     {
-        let idx = match idx.__idx(&self.columns) {
+        let idx = match idx.__idx(&self.fields) {
             Some(idx) => idx,
             None => return Err(Error::column(idx.to_string())),
         };
 
         let buf = self.ranges[idx].clone().map(|r| &self.body.buffer()[r]);
         FromSql::from_sql_nullable(&Type::TEXT, buf).map_err(|e| Error::from_sql(e, idx))
+    }
+}
+
+impl std::fmt::Debug for SimpleQueryRow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut values = Vec::with_capacity(self.len());
+        for i in 0..self.len() {
+            values.push(self.get(i).unwrap_or(""))
+        }
+        write!(f, "{:?}", values)
     }
 }


### PR DESCRIPTION
Adds the field information from the Row Description message to
SimpleQueryStream and propagates this information to SimpleQueryRow.
Previously, we took the column name from the fields and stored this as a
SimpleColumn.

This change was designed to limit the impact to the current SimpleQuery
interface. The field information is stored in a new OwnedField struct,
which is identical to the Field struct except that the name is stored as
a String. This allows the SimpleQueryMessage to outlive the
RowDescriptionBody.

We could instead store the RowDescriptionBody and attempt to parse it
when SimpleQueryRow::columns() is called. This is analogous to how the
row body is handled by SimpleQueryRow::get()/try_get(). However, this
approach was not taken to limit the changes to the current interface.

SimpleQueryRow::columns() now requires an allocation to return each
column as a SimpleColumn. This can be avoided by using the new
SimpleQueryRow::fields() method.