### PR TITLE
Expose SimpleQueryRow internals

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -565,6 +565,14 @@ pub struct DataRowBody {
 
 impl DataRowBody {
     #[inline]
+    pub fn new(storage: Bytes, len: u16) -> DataRowBody {
+        Self {
+            storage,
+            len,
+        }
+    }
+
+    #[inline]
     pub fn ranges(&self) -> DataRowRanges<'_> {
         DataRowRanges {
             buf: &self.storage,
@@ -916,6 +924,27 @@ pub struct OwnedField {
 }
 
 impl OwnedField {
+    #[inline]
+    pub fn new(
+        name: String,
+        table_oid: Oid,
+        column_id: i16,
+        type_oid: Oid,
+        type_size: i16,
+        type_modifier: i32,
+        format: i16,
+    ) -> Self {
+        Self {
+            name,
+            table_oid,
+            column_id,
+            type_oid,
+            type_size,
+            type_modifier,
+            format,
+        }
+    }
+
     #[inline]
     pub fn name(&self) -> &str {
         &self.name

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -211,7 +211,7 @@ pub struct SimpleQueryRow {
 
 impl SimpleQueryRow {
     #[allow(clippy::new_ret_no_self)]
-    pub(crate) fn new(
+    pub fn new(
         fields: Arc<[OwnedField]>,
         body: DataRowBody,
     ) -> Result<SimpleQueryRow, Error> {
@@ -245,6 +245,11 @@ impl SimpleQueryRow {
     /// Returns the number of values in the row.
     pub fn len(&self) -> usize {
         self.fields.len()
+    }
+
+    /// Returns the DataRowBody which stores the row as Bytes.
+    pub fn body(&self) -> &DataRowBody {
+        &self.body
     }
 
     /// Returns a value from the row.


### PR DESCRIPTION
Adds a function to expose the DataRowBody of a SimpleQueryRow. Also adds public constructors for OwnedField and DataRowBody, and makes the SimpleQueryRow constructor public.

The constructors are useful for integration testing since these structs are all available outside the module.