### PR TITLE
Fix CommandComplete not writing row description

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -435,13 +435,23 @@ impl BackendKeyDataBody {
 }
 
 pub struct CommandCompleteBody {
-    tag: Bytes,
+    pub tag: Bytes,
 }
 
 impl CommandCompleteBody {
     #[inline]
     pub fn tag(&self) -> io::Result<&str> {
         get_str(&self.tag)
+    }
+
+    #[inline]
+    pub fn tag_bytes(&self) -> &Bytes {
+        &self.tag
+    }
+
+    #[inline]
+    pub fn into_bytes(self) -> Bytes {
+        self.tag
     }
 }
 
@@ -566,10 +576,7 @@ pub struct DataRowBody {
 impl DataRowBody {
     #[inline]
     pub fn new(storage: Bytes, len: u16) -> DataRowBody {
-        Self {
-            storage,
-            len,
-        }
+        Self { storage, len }
     }
 
     #[inline]
@@ -803,6 +810,7 @@ impl ReadyForQueryBody {
     }
 }
 
+#[derive(Debug)]
 pub struct RowDescriptionBody {
     storage: Bytes,
     len: u16,
@@ -1007,6 +1015,6 @@ fn find_null(buf: &[u8], start: usize) -> io::Result<usize> {
 }
 
 #[inline]
-fn get_str(buf: &[u8]) -> io::Result<&str> {
+pub fn get_str(buf: &[u8]) -> io::Result<&str> {
     str::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))
 }

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -117,6 +117,8 @@
 #![doc(html_root_url = "https://docs.rs/tokio-postgres/0.7")]
 #![warn(rust_2018_idioms, clippy::all)]
 
+use std::sync::Arc;
+
 pub use crate::cancel_token::CancelToken;
 pub use crate::client::Client;
 pub use crate::config::Config;
@@ -141,8 +143,9 @@ pub use crate::to_statement::ToStatement;
 pub use crate::transaction::Transaction;
 pub use crate::transaction_builder::{IsolationLevel, TransactionBuilder};
 use crate::types::ToSql;
-pub use postgres_protocol::message::backend::OwnedField;
+use bytes::Bytes;
 pub use postgres_protocol::message::backend::Message;
+pub use postgres_protocol::message::backend::OwnedField;
 
 pub mod binary_copy;
 mod bind;
@@ -247,8 +250,18 @@ pub enum SimpleQueryMessage {
     Row(SimpleQueryRow),
     /// A statement in the query has completed.
     ///
-    /// The number of rows modified or selected is returned.
-    CommandComplete(u64),
+    /// The full tag, along with the rows modified or selected are returned.
+    CommandComplete(CommandCompleteContents),
+}
+
+#[derive(Eq, PartialEq, Debug)]
+pub struct CommandCompleteContents {
+    /// Fields, if relevant for the CommandCompleteContents.
+    pub fields: Option<Arc<[OwnedField]>>,
+    /// The number of rows modified or selected.
+    pub rows: u64,
+    /// The full tag in bytes of the CommandComplete body.
+    pub tag: Bytes,
 }
 
 fn slice_iter<'a>(

--- a/tokio-postgres/src/simple_query.rs
+++ b/tokio-postgres/src/simple_query.rs
@@ -7,7 +7,7 @@ use fallible_iterator::FallibleIterator;
 use futures::{ready, Stream};
 use log::debug;
 use pin_project_lite::pin_project;
-use postgres_protocol::message::backend::{OwnedField, Message};
+use postgres_protocol::message::backend::{Message, OwnedField};
 use postgres_protocol::message::frontend;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
@@ -94,10 +94,24 @@ impl Stream for SimpleQueryStream {
                         .unwrap()
                         .parse()
                         .unwrap_or(0);
-                    return Poll::Ready(Some(Ok(SimpleQueryMessage::CommandComplete(rows))));
+                    let fields = this.fields.clone();
+                    return Poll::Ready(Some(Ok(SimpleQueryMessage::CommandComplete(
+                        crate::CommandCompleteContents {
+                            fields,
+                            rows,
+                            tag: body.tag,
+                        },
+                    ))));
                 }
                 Message::EmptyQueryResponse => {
-                    return Poll::Ready(Some(Ok(SimpleQueryMessage::CommandComplete(0))));
+                    let fields = this.fields.clone();
+                    return Poll::Ready(Some(Ok(SimpleQueryMessage::CommandComplete(
+                        crate::CommandCompleteContents {
+                            fields,
+                            rows: 0,
+                            tag: Bytes::new(),
+                        },
+                    ))));
                 }
                 Message::RowDescription(body) => {
                     let fields = body

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -13,8 +13,8 @@ use tokio_postgres::error::SqlState;
 use tokio_postgres::tls::{NoTls, NoTlsStream};
 use tokio_postgres::types::{Kind, Type};
 use tokio_postgres::{
-    AsyncMessage, Client, Config, Connection, Error, GenericResult, IsolationLevel,
-    SimpleQueryMessage,
+    AsyncMessage, Client, CommandCompleteContents, Config, Connection, Error, GenericResult,
+    IsolationLevel, SimpleQueryMessage,
 };
 
 mod binary_copy;
@@ -319,11 +319,11 @@ async fn simple_query() {
         .unwrap();
 
     match messages[0] {
-        SimpleQueryMessage::CommandComplete(0) => {}
+        SimpleQueryMessage::CommandComplete(CommandCompleteContents { rows: 0, .. }) => {}
         _ => panic!("unexpected message"),
     }
     match messages[1] {
-        SimpleQueryMessage::CommandComplete(2) => {}
+        SimpleQueryMessage::CommandComplete(CommandCompleteContents { rows: 2, .. }) => {}
         _ => panic!("unexpected message"),
     }
     match &messages[2] {
@@ -345,7 +345,7 @@ async fn simple_query() {
         _ => panic!("unexpected message"),
     }
     match messages[4] {
-        SimpleQueryMessage::CommandComplete(2) => {}
+        SimpleQueryMessage::CommandComplete(CommandCompleteContents { rows: 2, .. }) => {}
         _ => panic!("unexpected message"),
     }
     assert_eq!(messages.len(), 5);


### PR DESCRIPTION
This change ensures that CommandComplete passes back both the full tag (which is necessary for distinguishing select from insert, update, delete etc. when getting an empty return) and ensures the row description gets sent back as well. This is necessary for returns from empty SELECT statements that still require writing back the row description.