### PR TITLE
Fix row description multi-write

### DIFF
--- a/postgres-protocol/src/message/backend.rs
+++ b/postgres-protocol/src/message/backend.rs
@@ -631,7 +631,7 @@ impl<'a> FallibleIterator for DataRowRanges<'a> {
                 ));
             }
             let base = self.len - self.buf.len();
-            self.buf = &self.buf[len as usize..];
+            self.buf = &self.buf[len..];
             Ok(Some(Some(base..base + len)))
         }
     }

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -218,18 +218,18 @@ async fn generic_query() {
         assert_eq!(row.get::<_, i32>(0), 1);
         assert_eq!(row.get::<_, &str>(1), "alice");
     } else {
-        assert!(false);
+        panic!();
     }
     if let GenericResult::Row(row) = s.next().unwrap() {
         assert_eq!(row.get::<_, i32>(0), 2);
         assert_eq!(row.get::<_, &str>(1), "bob");
     } else {
-        assert!(false);
+        panic!();
     }
     if let GenericResult::NumRows(rows_read) = s.next().unwrap() {
         assert_eq!(*rows_read, 2);
     } else {
-        assert!(false);
+        panic!();
     }
 }
 


### PR DESCRIPTION
In cases where SELECT would return empty results, an upstream user may need to still write out a row description. That's why in a previous commit we updated CommandComplete to include the fields. However, in cases where rows are being returned, we don't want to accidentally write more row descriptions than would be appropriate.

This adds logic to ensure that if we have written in data rows that we don't include the fields in the next follow up command complete we write. After writing such a command complete, we reset our bool that keeps track of whether we recently wrote data rows.