### PR TITLE
Implement changes to support passing through raw query result rows

### DIFF
--- a/tokio-postgres/src/bind.rs
+++ b/tokio-postgres/src/bind.rs
@@ -2,7 +2,7 @@ use crate::client::InnerClient;
 use crate::codec::FrontendMessage;
 use crate::connection::RequestMessages;
 use crate::types::BorrowToSql;
-use crate::{query, Error, Portal, Statement};
+use crate::{query, Error, Portal, Statement, DEFAULT_RESULT_FORMATS};
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -22,7 +22,7 @@ where
 {
     let name = format!("p{}", NEXT_ID.fetch_add(1, Ordering::SeqCst));
     let buf = client.with_buf(|buf| {
-        query::encode_bind(&statement, params, &name, buf)?;
+        query::encode_bind(&statement, params, &name, buf, DEFAULT_RESULT_FORMATS)?;
         frontend::sync(buf);
         Ok(buf.split().freeze())
     })?;

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -185,6 +185,15 @@ mod transaction;
 mod transaction_builder;
 pub mod types;
 
+/// This crate was originally written to use binary result format for pretty much everything, and
+/// it's still the case in most parts of the code that we hardcode to use binary. There are some
+/// small use cases we've hacked in where you can specify different result formats, though.
+/// Since Postgres lets you specify different result formats for different columns, we generally
+/// accept an IntoIterator<Item = i16> since each result format is specified as an i16 value of 0
+/// for text or 1 for binary. However, if you only specify a single format, Postgres interprets
+/// that as "use this format for everything", hence Some(1) being the default here:
+pub(crate) const DEFAULT_RESULT_FORMATS: Option<i16> = Some(1);
+
 /// A convenience function which parses a connection string and connects to the database.
 ///
 /// See the documentation for [`Config`] for details on the connection string format.

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -140,6 +140,11 @@ impl Row {
         self.columns().len()
     }
 
+    /// Returns the DataRowBody which stores the row as Bytes.
+    pub fn body(&self) -> &DataRowBody {
+        &self.body
+    }
+
     /// Deserializes a value from the row.
     ///
     /// The value can be specified either by its numeric index in the row, or by its column name.


### PR DESCRIPTION
These two commits are necessary for passing through the raw data rows for proxied queries when using the Parse/Bind/Describe/Exec path (as opposed to the SimpleQuery path, where this kind of passthrough is already implemented).

The bulk of the necessary changes are to let us specify custom result formats when we execute a query, since we need to specify the same result formats as the original client query if we want the results we pass through to match what the client expects. We also add a public accessor for the underlying row data on the Row type. See the individual commit messages in this PR for more detail.

(For more context on why I'm making these changes, see readysettech/readyset#268).