### PR TITLE
tokio-postgres: Expose table OID and column ID on Column

### DIFF
--- a/tokio-postgres/src/prepare.rs
+++ b/tokio-postgres/src/prepare.rs
@@ -95,7 +95,12 @@ pub async fn prepare(
         let mut it = row_description.fields();
         while let Some(field) = it.next().map_err(Error::parse)? {
             let type_ = get_type(client, field.type_oid()).await?;
-            let column = Column::new(field.name().to_string(), type_);
+            let column = Column::new(
+                field.name().to_string(),
+                type_,
+                Some(field.table_oid()).filter(|oid| *oid != 0),
+                Some(field.column_id()).filter(|id| *id != 0),
+            );
             columns.push(column);
         }
     }

--- a/tokio-postgres/src/statement.rs
+++ b/tokio-postgres/src/statement.rs
@@ -68,11 +68,23 @@ impl Statement {
 pub struct Column {
     name: String,
     type_: Type,
+    table_oid: Option<u32>,
+    column_id: Option<i16>,
 }
 
 impl Column {
-    pub(crate) fn new(name: String, type_: Type) -> Column {
-        Column { name, type_ }
+    pub(crate) fn new(
+        name: String,
+        type_: Type,
+        table_oid: Option<u32>,
+        column_id: Option<i16>,
+    ) -> Column {
+        Column {
+            name,
+            type_,
+            table_oid,
+            column_id,
+        }
     }
 
     /// Returns the name of the column.
@@ -83,6 +95,17 @@ impl Column {
     /// Returns the type of the column.
     pub fn type_(&self) -> &Type {
         &self.type_
+    }
+
+    /// Returns the oid of the column's table, if it is a direct alias to a column in a table
+    pub fn table_oid(&self) -> Option<u32> {
+        self.table_oid
+    }
+
+    /// Returns the column's attribute number in its table, if it is a direct alias to a column in a
+    /// table
+    pub fn column_id(&self) -> Option<i16> {
+        self.column_id
     }
 }
 


### PR DESCRIPTION
Pass through the table OID and column ID from field descriptions for prepared statements to fields on Column, with exposed getters