### PR TITLE
Bump socket2

### DIFF
--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -55,7 +55,7 @@ pin-project-lite = "0.2"
 phf = "0.11"
 postgres-protocol = { version = "0.6.4", path = "../postgres-protocol" }
 postgres-types = { version = "0.2.4", path = "../postgres-types" }
-socket2 = "0.4"
+socket2 = { version = "0.5", features = ["all"] }
 tokio = { version = "1.0", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 


### PR DESCRIPTION
Bump the version of socket2 we depend on to 0.5, to work around an incompatibility with a newer tokio's dependency on socket2