### PR TITLE
Add upstream PG's CommandCompletion Tag to GenericResult

### DIFF
--- a/tokio-postgres/src/generic_result.rs
+++ b/tokio-postgres/src/generic_result.rs
@@ -5,5 +5,5 @@ use crate::Row;
 #[derive(Debug)]
 pub enum GenericResult {
     Row(Row),
-    NumRows(u64),
+    Command(u64, String),
 }

--- a/tokio-postgres/src/query.rs
+++ b/tokio-postgres/src/query.rs
@@ -272,15 +272,9 @@ impl Stream for ResultStream {
             )?)))),
             Message::CommandComplete(body) => {
                 // parse value from bytes
-                let val = body
-                    .tag()
-                    .map_err(Error::parse)?
-                    .rsplit(' ')
-                    .next()
-                    .unwrap()
-                    .parse()
-                    .unwrap_or(0);
-                Poll::Ready(Some(Ok(GenericResult::NumRows(val))))
+                let tag = body.tag().map_err(Error::parse)?;
+                let val = tag.rsplit(' ').next().unwrap().parse().unwrap_or(0);
+                Poll::Ready(Some(Ok(GenericResult::Command(val, tag.to_string()))))
             }
             Message::EmptyQueryResponse | Message::PortalSuspended => Poll::Ready(None),
             Message::ErrorResponse(body) => Poll::Ready(Some(Err(Error::db(body)))),

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -210,7 +210,7 @@ async fn generic_query() {
 
     let rows_written = match insert[0] {
         GenericResult::Row(_) => 0, // failure case
-        GenericResult::NumRows(r) => r,
+        GenericResult::Command(r, _) => r,
     };
     assert_eq!(rows_written, 2);
     let mut s = select.iter();
@@ -226,7 +226,7 @@ async fn generic_query() {
     } else {
         panic!();
     }
-    if let GenericResult::NumRows(rows_read) = s.next().unwrap() {
+    if let GenericResult::Command(rows_read, _) = s.next().unwrap() {
         assert_eq!(*rows_read, 2);
     } else {
         panic!();


### PR DESCRIPTION
Currently, the `ResultStream` for a query returns either the rows that were selected (`GenerciResult::Row`), or the number of rows modified by the statement (`GenericResult::NumRows`). `NumRows` is insufficient for Readyset's needs not all statement executed this way "modify rows". Thus, we need the actual Tag data from the upstream postgres's CommandCompletion message that was returned from PG so we can ship it back to our callers. Luckily, the `Message::CommandComplete` already has this data, we just need to expose it in the API.

This patch renames `GenericResult::NumRows` to
`GenericResult::Command`, and adds the Tag data into the enum variant. The important part is adding the tag data to the variant, but the name change makes the variant more appropriate.

Fixes: https://github.com/readysettech/readyset/issues/1038