### PR TITLE
tokio-postgres: expose simple_query_raw

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -497,7 +497,7 @@ impl Client {
         self.simple_query_raw(query).await?.try_collect().await
     }
 
-    pub(crate) async fn simple_query_raw(&self, query: &str) -> Result<SimpleQueryStream, Error> {
+    pub async fn simple_query_raw(&self, query: &str) -> Result<SimpleQueryStream, Error> {
         simple_query::simple_query(self.inner(), query).await
     }
 


### PR DESCRIPTION
This makes `simple_query_raw` a pub fn so we can use the SimpleQueryStream to stream text protocol messages.